### PR TITLE
SQLログを取れるようにした

### DIFF
--- a/docker/mariadb/my.cnf
+++ b/docker/mariadb/my.cnf
@@ -1,2 +1,7 @@
 [mysqld]
 sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+
+# query log
+general_log=ON
+general_log_file=~/.mysql/general.log
+log_output=FILE


### PR DESCRIPTION
## 参考

- https://server-setting.info/centos/mysql-log-type.html

## Setup

```sh
$ mkdir ~/.mysql
$ MYSQL_HOME=$PWD/docker/mariadb mysql.server restart
```

## log

```
Time                 Id Command    Argument
                   14 Query     SELECT * FROM reservations WHERE event_id = '14' AND sheet_id = '10' AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)
                   14 Query     SELECT * FROM reservations WHERE event_id = '14' AND sheet_id = '11' AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)
                   14 Query     SELECT * FROM reservations WHERE event_id = '14' AND sheet_id = '12' AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)
                   14 Query     SELECT * FROM reservations WHERE event_id = '14' AND sheet_id = '13' AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)
                   14 Query     SELECT * FROM reservations WHERE event_id = '14' AND sheet_id = '14' AND canceled_at IS NULL GROUP BY event_id, sheet_id HAVING reserved_at = MIN(reserved_at)
```