### PR TITLE
[score: 6365] GET /admin/api/reports/salesの修正

### DIFF
--- a/lib/torb/web.rb
+++ b/lib/torb/web.rb
@@ -203,6 +203,7 @@ module Torb
 
       def render_report_csv(reports)
         measure(key: "render_report_csv") do
+        # 呼び出し元でsortしていないので絶対外さない
         reports = reports.sort_by { |report| report[:sold_at] }
 
         keys = %i[reservation_id event_id rank num price user_id sold_at canceled_at]
@@ -553,7 +554,7 @@ module Torb
       events     = db.query('SELECT id, price FROM events')
       event_hash = events.each_with_object({}) {|event, hash| hash[event["id"]] = event["price"] }
 
-      reservations = db.query('SELECT * FROM reservations ORDER BY reserved_at ASC FOR UPDATE')
+      reservations = db.query('SELECT * FROM reservations FOR UPDATE')
       reports = reservations.map do |reservation|
         {
           reservation_id: reservation['id'],


### PR DESCRIPTION
## 実行計画

### 初期状態

reservationsテーブルが20万件ほどあるのでjoinすると遅い（joinなしでも遅い）
sheetsテーブルはマスターデータのようなもの、かつeventsテーブルも件数が少ないので別々にquery実行してhashデータを作るように変更する
```sql
> explain
> SELECT
>   r.*, s.rank AS sheet_rank, s.num AS sheet_num, s.price AS sheet_price, e.id AS event_id, e.price AS event_price
> FROM
>   reservations r
>   INNER JOIN sheets s ON s.id = r.sheet_id
>   INNER JOIN events e ON e.id = r.event_id
> ORDER BY
>   reserved_at ASC;
+----+-------------+-------+------+---------------------------+---------------------------+---------+---------------------+------+---------------------------------------+
| id | select_type | table | type | possible_keys             | key                       | key_len | ref                 | rows | Extra                                 |
+----+-------------+-------+------+---------------------------+---------------------------+---------+---------------------+------+---------------------------------------+
|  1 | SIMPLE      | e     | ALL  | PRIMARY                   | NULL                      | NULL    | NULL                |   20 | Using temporary; Using filesort       |
|  1 | SIMPLE      | s     | ALL  | PRIMARY                   | NULL                      | NULL    | NULL                | 1000 | Using join buffer (Block Nested Loop) |
|  1 | SIMPLE      | r     | ref  | event_id_and_sheet_id_idx | event_id_and_sheet_id_idx | 8       | torb.e.id,torb.s.id |    6 | NULL                                  |
+----+-------------+-------+------+---------------------------+---------------------------+---------+---------------------+------+---------------------------------------+
3 rows in set (0.00 sec)
```

### ~~分割後のクエリ~~

~~全件(約20万件)をソートして取得しようとしているため、index張っても意味なし~~
~~50000件ごとに取得するように変更する~~

```sql
> explain SELECT * FROM reservations ORDER BY reserved_at ASC;
+----+-------------+--------------+------+---------------+------+---------+------+--------+----------------+
| id | select_type | table        | type | possible_keys | key  | key_len | ref  | rows   | Extra          |
+----+-------------+--------------+------+---------------+------+---------+------+--------+----------------+
|  1 | SIMPLE      | reservations | ALL  | NULL          | NULL | NULL    | NULL | 191684 | Using filesort |
+----+-------------+--------------+------+---------------+------+---------+------+--------+----------------+
1 row in set (0.00 sec)
```

<a href="https://gyazo.com/3cc03678b36835be3a58a221d299d25b"><img src="https://i.gyazo.com/3cc03678b36835be3a58a221d299d25b.png" alt="Image from Gyazo" width="400"/></a>