### PR TITLE
Sheetテーブルのrankカラムにインデックスを追加した

### DIFF
--- a/db/init.sh
+++ b/db/init.sh
@@ -10,6 +10,8 @@ export MYSQL_HOST=127.0.0.1
 mysql -uisucon -e "DROP DATABASE IF EXISTS torb; CREATE DATABASE torb;"
 mysql -uisucon torb < "$DB_DIR/schema.sql"
 
+mysql -uisucon torb -e 'ALTER TABLE sheets ADD INDEX index_sheets_on_num(rank)'
+
 if [ ! -f "$DB_DIR/isucon8q-initial-dataset.sql.gz" ]; then
   echo "Run the following command beforehand." 1>&2
   echo "$ ( cd \"$BENCH_DIR\" && bin/gen-initial-dataset )" 1>&2

--- a/db/init.sh
+++ b/db/init.sh
@@ -10,6 +10,7 @@ export MYSQL_HOST=127.0.0.1
 mysql -uisucon -e "DROP DATABASE IF EXISTS torb; CREATE DATABASE torb;"
 mysql -uisucon torb < "$DB_DIR/schema.sql"
 
+# 変更
 mysql -uisucon torb -e 'ALTER TABLE sheets ADD INDEX index_sheets_on_num(rank)'
 
 if [ ! -f "$DB_DIR/isucon8q-initial-dataset.sql.gz" ]; then


### PR DESCRIPTION
## Description
以下の条件を満たしているのでインデックスを貼ってみた。

- テーブル内のデータ量が多い
- ~~少量のレコード（種類が少ない）~~ <= 真逆だ！！
- where句の条件として何回か登場している

追記）
- インデックスカラムの基本的な考え方は、カーディナリティが高いものにはれである
- カーディナリティが低い場合でも、データのばらつきが多い場合はインデックスは有効となることがある（例えば、フラグをつかている時、1（処理済み）が９割、０（未処理）が１割のような時だ

カーディナリティが低い場合に関してのREF： [MySQL(InnoDB)でカーディナリティの低いカラムにINDEXを張る
](https://qiita.com/hmatsu47/items/2d44c173a9114fd06853)

