### PR TITLE
スロークエリのログと分析方法を追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ $ docker-compose down -v
 # Use Native
 mysql.server stop
 ```
+## MariaDB ベンチマーク
+#### 平均実行時間
+```
+$ dc exec db mysqldumpslow -s at /var/log/mysql/slow.log -t 10
+```
+
+#### クエリ合計時間
+```
+$ dc exec db mysqldumpslow -s t /var/log/mysql/slow.log -t 10
+```

--- a/docker/mariadb/my.cnf
+++ b/docker/mariadb/my.cnf
@@ -5,3 +5,8 @@ sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_
 general_log=OFF
 general_log_file=/var/log/mysql/general.log
 log_output=FILE
+
+## slow query
+slow_query_log = 1
+slow_query_log_file=/var/log/mysql/slow.log
+long_query_time = 0

--- a/docker/mariadb/my.cnf
+++ b/docker/mariadb/my.cnf
@@ -7,6 +7,6 @@ general_log_file=/var/log/mysql/general.log
 log_output=FILE
 
 ## slow query
-slow_query_log = 1
+slow_query_log = 0 # onにする場合は1にする
 slow_query_log_file=/var/log/mysql/slow.log
 long_query_time = 0


### PR DESCRIPTION
## Description
- docker のスロウクエリのログの出力設定を追加した
- mysqldumpslowを利用すれば、クエリ実行時間ランキング、クエリ合計時間ランキングを知ることができる